### PR TITLE
Fixes input append height in Gutenberg

### DIFF
--- a/assets/build/css/_fields.scss
+++ b/assets/build/css/_fields.scss
@@ -526,6 +526,10 @@
 	
 	background: #F4F4F4;
 	border: #DFDFDF solid 1px;
+	
+	.block-editor-page & {
+		height: auto;
+	}
 }
 
 .acf-input-prepend {


### PR DESCRIPTION
Input append and prepend shows in smaller height than needed. This fixes it.
![Screen Shot 2019-03-25 at 12 33 03](https://user-images.githubusercontent.com/4457340/54913682-f541d180-4efb-11e9-8868-45bb9338a029.png)
